### PR TITLE
Update testing/integration.md to use ResetAllMartenDataAsync()

### DIFF
--- a/docs/testing/integration.md
+++ b/docs/testing/integration.md
@@ -100,8 +100,9 @@ public abstract class IntegrationContext : IAsyncLifetime
      
     public async Task InitializeAsync()
     {
-        // Using Marten, wipe out all data and reset the state
-        await Store.Advanced.ResetAllData();
+        // Using Marten, wipe out all data and reset the state.
+        // Also restart the async daemon if in use.
+        await Host.ResetAllMartenDataAsync();
     }
  
     // This is required because of the IAsyncLifetime 


### PR DESCRIPTION
Store.Advanced.ResetAllData() is part of what we need to do, but if you use the AsyncDaemon in your setup, all tests after the first one will timeout on Store.WaitForNonStaleProjectionDataAsync().